### PR TITLE
Add FFMpeg fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "ext-json": "*",
         "symfony/console": ">5.0",
         "james-heinrich/getid3": "v2.0.0-beta4",
-        "voku/portable-utf8": "^6"
+        "voku/portable-utf8": "^6",
+        "php-ffmpeg/php-ffmpeg": "^1.0"
     },
     "require-dev": {
         "php-parallel-lint/php-console-highlighter": "^1",

--- a/src/Command/ReadCommand.php
+++ b/src/Command/ReadCommand.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace Azura\MetadataManager\Command;
 
-use Azura\MetadataManager\Metadata;
-use Azura\MetadataManager\Utilities\Arrays;
-use Azura\MetadataManager\Utilities\Time;
-use JamesHeinrich\GetID3\GetID3;
+use Azura\MetadataManager\Exception\ReadException;
+use Azura\MetadataManager\Reader\FfmpegReader;
+use Azura\MetadataManager\Reader\GetId3Reader;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use voku\helper\UTF8;
-
-use const JSON_THROW_ON_ERROR;
+use Throwable;
 
 class ReadCommand extends Command
 {
@@ -48,107 +45,30 @@ class ReadCommand extends Command
             return 1;
         }
 
-        $id3 = new GetID3();
-
-        $id3->option_md5_data = true;
-        $id3->option_md5_data_source = true;
-        $id3->encoding = 'UTF-8';
-
-        $info = $id3->analyze($path);
-        $id3->CopyTagsToComments($info);
-
-        if (!empty($info['error'])) {
-            $io->error(
-                sprintf(
-                    'Cannot process media at path %s: %s',
-                    pathinfo($path, PATHINFO_FILENAME),
-                    json_encode($info['error'], JSON_THROW_ON_ERROR)
-                )
-            );
+        try {
+            if (!$this->tryReadWithGetId3Reader($path, $jsonOutput, $artOutput)) {
+                FfmpegReader::read($path, $jsonOutput, $artOutput);
+            }
+        } catch (Throwable $exception) {
+            $io->error($exception->getMessage());
             return 1;
-        }
-
-        $metadata = new Metadata();
-
-        if (is_numeric($info['playtime_seconds'])) {
-            $metadata->setDuration(
-                Time::displayTimeToSeconds($info['playtime_seconds']) ?? 0.0
-            );
-        }
-
-        $metaTags = [];
-
-        $toProcess = [
-            $info['comments'] ?? null,
-            $info['tags'] ?? null,
-        ];
-
-        foreach ($toProcess as $tagSet) {
-            if (empty($tagSet)) {
-                continue;
-            }
-
-            foreach ($tagSet as $tagName => $tagContents) {
-                if (!empty($tagContents[0]) && !isset($metaTags[$tagName])) {
-                    $tagValue = $tagContents[0];
-                    if (is_array($tagValue)) {
-                        // Skip pictures
-                        if (isset($tagValue['data'])) {
-                            continue;
-                        }
-                        $flatValue = Arrays::flattenArray($tagValue);
-                        $tagValue = implode(', ', $flatValue);
-                    }
-
-                    $metaTags[(string)$tagName] = $this->cleanUpString((string)$tagValue);
-                }
-            }
-        }
-
-        $metadata->setTags($metaTags);
-        $metadata->setMimeType($info['mime_type']);
-
-        file_put_contents(
-            $jsonOutput,
-            json_encode($metadata, JSON_THROW_ON_ERROR),
-        );
-
-        if (null !== $artOutput) {
-            $artwork = null;
-            if (!empty($info['attached_picture'][0])) {
-                $artwork = $info['attached_picture'][0]['data'];
-            } elseif (!empty($info['comments']['picture'][0])) {
-                $artwork = $info['comments']['picture'][0]['data'];
-            } elseif (!empty($info['id3v2']['APIC'][0]['data'])) {
-                $artwork = $info['id3v2']['APIC'][0]['data'];
-            } elseif (!empty($info['id3v2']['PIC'][0]['data'])) {
-                $artwork = $info['id3v2']['PIC'][0]['data'];
-            }
-
-            if (!empty($artwork)) {
-                file_put_contents(
-                    $artOutput,
-                    $artwork
-                );
-            }
         }
 
         return 0;
     }
 
-    protected function cleanUpString(?string $original): string
-    {
-        $original ??= '';
+    protected function tryReadWithGetId3Reader(
+        string $path,
+        string $jsonOutput,
+        ?string $artOutput
+    ): bool {
+        try {
+            GetId3Reader::read($path, $jsonOutput, $artOutput);
 
-        $string = UTF8::encode('UTF-8', $original);
-        $string = UTF8::fix_simple_utf8($string);
-        return UTF8::clean(
-            $string,
-            true,
-            true,
-            true,
-            true,
-            true
-        );
+            return true;
+        }
+        catch (Throwable) {
+            return false;
+        }
     }
 }

--- a/src/Command/ReadCommand.php
+++ b/src/Command/ReadCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Azura\MetadataManager\Command;
 
-use Azura\MetadataManager\Exception\ReadException;
 use Azura\MetadataManager\Reader\FfmpegReader;
 use Azura\MetadataManager\Reader\GetId3Reader;
 use Symfony\Component\Console\Command\Command;

--- a/src/Exception/ReadException.php
+++ b/src/Exception/ReadException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azura\MetadataManager\Exception;
+
+use Exception;
+
+class ReadException extends Exception
+{
+}

--- a/src/Reader/AbstractReader.php
+++ b/src/Reader/AbstractReader.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azura\MetadataManager\Reader;
+
+use Azura\MetadataManager\Utilities\Arrays;
+use voku\helper\UTF8;
+
+abstract class AbstractReader implements ReaderInterface
+{
+    abstract public static function read(
+        string $path,
+        string $jsonOutput,
+        ?string $artOutput
+    ): void;
+
+    protected static function aggregateMetaTags(array $toProcess): array
+    {
+        $metaTags = [];
+
+        foreach ($toProcess as $tagSet) {
+            if (empty($tagSet)) {
+                continue;
+            }
+
+            foreach ($tagSet as $tagName => $tagContents) {
+                if (!empty($tagContents[0]) && !isset($metaTags[$tagName])) {
+                    $tagValue = $tagContents[0];
+                    if (is_array($tagValue)) {
+                        // Skip pictures
+                        if (isset($tagValue['data'])) {
+                            continue;
+                        }
+                        $flatValue = Arrays::flattenArray($tagValue);
+                        $tagValue = implode(', ', $flatValue);
+                    }
+
+                    $metaTags[(string)$tagName] = self::cleanUpString((string)$tagValue);
+                }
+            }
+        }
+
+        return $metaTags;
+    }
+
+    protected static function cleanUpString(?string $original): string
+    {
+        $original ??= '';
+
+        $string = UTF8::encode('UTF-8', $original);
+        $string = UTF8::fix_simple_utf8($string);
+        return UTF8::clean(
+            $string,
+            true,
+            true,
+            true,
+            true,
+            true
+        );
+    }
+}

--- a/src/Reader/FfmpegReader.php
+++ b/src/Reader/FfmpegReader.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azura\MetadataManager\Reader;
+
+use Azura\MetadataManager\Metadata;
+use Azura\MetadataManager\Utilities\Time;
+use FFMpeg\FFMpeg;
+use FFMpeg\FFProbe;
+use FFMpeg\FFProbe\DataMapping\Stream;
+
+use const JSON_THROW_ON_ERROR;
+
+class FfmpegReader extends AbstractReader
+{
+    public static function read(
+        string $path,
+        string $jsonOutput,
+        ?string $artOutput
+    ): void {
+        $ffprobe = FFProbe::create();
+
+        $format = $ffprobe->format($path);
+
+        $metadata = new Metadata();
+
+        if (is_numeric($format->get('duration'))) {
+            $metadata->setDuration(
+                Time::displayTimeToSeconds($format->get('duration')) ?? 0.0
+            );
+        }
+
+        $metaTags = [];
+
+        $toProcess = [
+            $format->get('comments'),
+            $format->get('tags'),
+        ];
+
+        $metaTags = self::aggregateMetaTags($toProcess);
+
+        $metadata->setTags($metaTags);
+        $metadata->setMimeType(mime_content_type($path) ?: '');
+
+        file_put_contents(
+            $jsonOutput,
+            json_encode($metadata, JSON_THROW_ON_ERROR),
+        );
+
+        if (null !== $artOutput) {
+            $ffmpeg = FFMpeg::create();
+
+            /** @var Stream[] $videoStreams */
+            $videoStreams = $ffprobe->streams($path)->videos()->all();
+            foreach ($videoStreams as $videoStream) {
+                $codecName = $videoStream->get('codec_name');
+
+                if ($codecName !== 'mjpeg') {
+                    continue;
+                }
+
+                $ffmpeg->getFFMpegDriver()->command([
+                    '-i', $path,
+                    '-an', '-vcodec',
+                    'copy', $artOutput
+                ]);
+
+                break;
+            }
+        }
+    }
+}

--- a/src/Reader/GetId3Reader.php
+++ b/src/Reader/GetId3Reader.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azura\MetadataManager\Reader;
+
+use Azura\MetadataManager\Exception\ReadException;
+use Azura\MetadataManager\Metadata;
+use Azura\MetadataManager\Utilities\Time;
+use JamesHeinrich\GetID3\GetID3;
+
+use const JSON_THROW_ON_ERROR;
+
+class GetId3Reader extends AbstractReader
+{
+    public static function read(
+        string $path,
+        string $jsonOutput,
+        ?string $artOutput
+    ): void {
+        $id3 = new GetID3();
+
+        $id3->option_md5_data = true;
+        $id3->option_md5_data_source = true;
+        $id3->encoding = 'UTF-8';
+
+        $info = $id3->analyze($path);
+        $id3->CopyTagsToComments($info);
+
+        if (!empty($info['error'])) {
+            throw new ReadException(
+                sprintf(
+                    'Cannot process media at path %s: %s',
+                    pathinfo($path, PATHINFO_FILENAME),
+                    json_encode($info['error'], JSON_THROW_ON_ERROR)
+                )
+            );
+        }
+
+        $metadata = new Metadata();
+
+        if (is_numeric($info['playtime_seconds'])) {
+            $metadata->setDuration(
+                Time::displayTimeToSeconds($info['playtime_seconds']) ?? 0.0
+            );
+        }
+
+        $toProcess = [
+            $info['comments'] ?? null,
+            $info['tags'] ?? null,
+        ];
+
+        $metaTags = self::aggregateMetaTags($toProcess);
+
+        $metadata->setTags($metaTags);
+        $metadata->setMimeType($info['mime_type']);
+
+        file_put_contents(
+            $jsonOutput,
+            json_encode($metadata, JSON_THROW_ON_ERROR),
+        );
+
+        if (null !== $artOutput) {
+            $artwork = null;
+            if (!empty($info['attached_picture'][0])) {
+                $artwork = $info['attached_picture'][0]['data'];
+            } elseif (!empty($info['comments']['picture'][0])) {
+                $artwork = $info['comments']['picture'][0]['data'];
+            } elseif (!empty($info['id3v2']['APIC'][0]['data'])) {
+                $artwork = $info['id3v2']['APIC'][0]['data'];
+            } elseif (!empty($info['id3v2']['PIC'][0]['data'])) {
+                $artwork = $info['id3v2']['PIC'][0]['data'];
+            }
+
+            if (!empty($artwork)) {
+                file_put_contents(
+                    $artOutput,
+                    $artwork
+                );
+            }
+        }
+    }
+}

--- a/src/Reader/ReaderInterface.php
+++ b/src/Reader/ReaderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azura\MetadataManager\Reader;
+
+interface ReaderInterface
+{
+    public static function read(
+        string $path,
+        string $jsonOutput,
+        ?string $artOutput
+    ): void;
+}


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR adds a fallback for reading metadata via FFMpeg if the processing via getID3 fails.

Feel free to point out anything you'd like to have revisited architecturally.
I've tried to keep the changes as simple as possible so some parts might be less optimal as they could be.

I have looked into adding a fallback to FFMpeg for the metadata writing too but the `PHP-FFMpeg` lib currently does not have a "copy" audio codec defined. FFMpeg itself can definitely do a "map metadata and otherwise just copy the audio streams of a file to the same format" but I'd need to add such a custom "codec" definition myself. So I opted to omit this from this PR for now.