### PR TITLE
Fix metadata access for ffmpeg reader

### DIFF
--- a/src/Reader/AbstractReader.php
+++ b/src/Reader/AbstractReader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Azura\MetadataManager\Reader;
 
-use Azura\MetadataManager\Utilities\Arrays;
 use voku\helper\UTF8;
 
 abstract class AbstractReader implements ReaderInterface
@@ -14,35 +13,6 @@ abstract class AbstractReader implements ReaderInterface
         string $jsonOutput,
         ?string $artOutput
     ): void;
-
-    protected static function aggregateMetaTags(array $toProcess): array
-    {
-        $metaTags = [];
-
-        foreach ($toProcess as $tagSet) {
-            if (empty($tagSet)) {
-                continue;
-            }
-
-            foreach ($tagSet as $tagName => $tagContents) {
-                if (!empty($tagContents[0]) && !isset($metaTags[$tagName])) {
-                    $tagValue = $tagContents[0];
-                    if (is_array($tagValue)) {
-                        // Skip pictures
-                        if (isset($tagValue['data'])) {
-                            continue;
-                        }
-                        $flatValue = Arrays::flattenArray($tagValue);
-                        $tagValue = implode(', ', $flatValue);
-                    }
-
-                    $metaTags[(string)$tagName] = self::cleanUpString((string)$tagValue);
-                }
-            }
-        }
-
-        return $metaTags;
-    }
 
     protected static function cleanUpString(?string $original): string
     {

--- a/src/Reader/FfmpegReader.php
+++ b/src/Reader/FfmpegReader.php
@@ -41,8 +41,6 @@ class FfmpegReader extends AbstractReader
 
         $metaTags = self::aggregateMetaTags($toProcess);
 
-        file_put_contents(__DIR__ . '/test1.json', json_encode($metaTags, JSON_PRETTY_PRINT));
-
         $metadata->setTags($metaTags);
         $metadata->setMimeType(mime_content_type($path) ?: '');
 

--- a/src/Reader/GetId3Reader.php
+++ b/src/Reader/GetId3Reader.php
@@ -6,6 +6,7 @@ namespace Azura\MetadataManager\Reader;
 
 use Azura\MetadataManager\Exception\ReadException;
 use Azura\MetadataManager\Metadata;
+use Azura\MetadataManager\Utilities\Arrays;
 use Azura\MetadataManager\Utilities\Time;
 use JamesHeinrich\GetID3\GetID3;
 
@@ -79,5 +80,34 @@ class GetId3Reader extends AbstractReader
                 );
             }
         }
+    }
+
+    protected static function aggregateMetaTags(array $toProcess): array
+    {
+        $metaTags = [];
+
+        foreach ($toProcess as $tagSet) {
+            if (empty($tagSet)) {
+                continue;
+            }
+
+            foreach ($tagSet as $tagName => $tagContents) {
+                if (!empty($tagContents[0]) && !isset($metaTags[$tagName])) {
+                    $tagValue = $tagContents[0];
+                    if (is_array($tagValue)) {
+                        // Skip pictures
+                        if (isset($tagValue['data'])) {
+                            continue;
+                        }
+                        $flatValue = Arrays::flattenArray($tagValue);
+                        $tagValue = implode(', ', $flatValue);
+                    }
+
+                    $metaTags[(string)$tagName] = self::cleanUpString((string)$tagValue);
+                }
+            }
+        }
+
+        return $metaTags;
     }
 }


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR fixes an issue with the FFmpeg metadata reader where it only ever returns the first char of the metadata tags value due to them being accessed as if they were an array of values (which is how it is done for getID3, where this is needed).
